### PR TITLE
Added a check for the existence of scrollView before trying to call methods on it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,9 +62,13 @@ var ScrollableTabView = React.createClass({
 
     if(Platform.OS === 'ios') {
       var offset = pageNumber * this.state.container.width;
-      this.scrollView.scrollTo(0, offset);
+      if (this.scrollView) {
+        this.scrollView.scrollTo(0, offset);  
+      }
     } else {
-      this.scrollView.setPage(pageNumber);
+      if (this.scrollView) {
+        this.scrollView.setPage(pageNumber);
+      }
     }
 
     this.setState({currentPage: pageNumber});


### PR DESCRIPTION
This pulls in [a commit from the main repo](https://github.com/skv-headless/react-native-scrollable-tab-view/commit/9d3383d41772b2ec64b37e6b03dfef5dfbfe0176) that fixes a [sentry crash](https://app.getsentry.com/iodine/js/issues/111374151/).

R: @mfmendiola 
